### PR TITLE
Add extra check in validateVATNumber

### DIFF
--- a/Service/Validate/Vatlayer.php
+++ b/Service/Validate/Vatlayer.php
@@ -59,6 +59,10 @@ class Vatlayer implements ValidationServiceInterface
         } catch (\Exception $error) {
             throw new FailedValidationException("HTTP error {$error->getMessage()}");
         }
+        
+        if (isset($clientResponse['error'])) {
+            throw new FailedValidationException($clientResponse['error']['info']);
+        }
 
         return (bool)$clientResponse['valid'];
     }


### PR DESCRIPTION
Vatlayer API can return errors if for example monthly usage limit has been reached. In this case $clientResponse will not have key: 'valid', so exception.log is flooded by: `Notice: Undefined index: valid`

Vatlayer documentation tells us error key will exist if there is an error. The error info is now also visible in the FailedValidationException.