### PR TITLE
Possibility to make services stop further processing if 100% sure

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,8 +24,13 @@ Please find the [Magento 1 version here](https://github.com/sandermangel/rkvatfa
 ## Tested on
 
 - Magento 2.2 Community & Commerce
+- Magento 2.3 Community
 
 ## Changelog
+[1.5.0] Better error handling if services are unavailable, no next service checking if 100% sure invalid result
+
+[1.4.0] Refactor __constructors, decoupled validationservices from validator
+
 [1.3.0] Regex validation now configurable via XML. Improved tests and regex validation
 
 [1.2.0] added a timeout sys conf value for connecting to APIs
@@ -47,6 +52,7 @@ Warning: Since all of the free VIES API's are slow and somewhat unreliable the c
 ## Authors
 
 - Sander Mangel [Github](https://github.com/sandermangel) [Twitter](https://twitter.com/sandermangel)
+- Jeroen Boersma [Github](https://github.com/jeroenboersma) [Twitter](https://twitter.com/srcoder)
 - Timon de Groot [Github](https://github.com/tdgroot) [Twitter](https://twitter.com/TimonGreat)
 
 ### Authors M1 Version

--- a/Service/Configuration.php
+++ b/Service/Configuration.php
@@ -58,4 +58,10 @@ class Configuration implements ConfigurationInterface
             ->getConfig(self::XMLPATH_CUSTOMER_VATFALLBACK_VATLAYER_TIMEOUT);
     }
 
+    public function isRegExpValidation(StoreInterface $store = null): bool
+    {
+        return (bool)$this->storeManager
+            ->getStore($store)
+            ->getConfig(self::XMLPATH_CUSTOMER_VATFALLBACK_REGEXP_VALIDATION);
+    }
 }

--- a/Service/ConfigurationInterface.php
+++ b/Service/ConfigurationInterface.php
@@ -15,6 +15,8 @@ interface ConfigurationInterface
     const XMLPATH_CUSTOMER_VATFALLBACK_VATLAYER_APIKEY = 'vatfallback/vatfallback/vatlayer_apikey';
     const XMLPATH_CUSTOMER_VATFALLBACK_VATLAYER_TIMEOUT = 'vatfallback/vatfallback/vatlayer_timeout';
 
+    const XMLPATH_CUSTOMER_VATFALLBACK_REGEXP_VALIDATION = 'vatfallback/vatfallback/regexp_validation';
+
     public function isViesValidation(StoreInterface $store = null): bool;
     public function getViesTimeout(StoreInterface $store = null): int;
 
@@ -22,5 +24,6 @@ interface ConfigurationInterface
     public function getVatlayerApikey(StoreInterface $store = null): string;
     public function getVatlayerTimeout(StoreInterface $store = null): int;
 
+    public function isRegExpValidation(StoreInterface $store = null): bool;
 
 }

--- a/Service/Exceptions/GenericException.php
+++ b/Service/Exceptions/GenericException.php
@@ -1,0 +1,10 @@
+<?php
+
+
+namespace Dutchento\Vatfallback\Service\Exceptions;
+
+
+class GenericException extends \RuntimeException
+{
+
+}

--- a/Service/Exceptions/InvalidConfigurationException.php
+++ b/Service/Exceptions/InvalidConfigurationException.php
@@ -1,0 +1,10 @@
+<?php
+
+
+namespace Dutchento\Vatfallback\Service\Exceptions;
+
+
+class InvalidConfigurationException extends GenericException
+{
+
+}

--- a/Service/Exceptions/ValidationDisabledException.php
+++ b/Service/Exceptions/ValidationDisabledException.php
@@ -1,0 +1,10 @@
+<?php
+
+
+namespace Dutchento\Vatfallback\Service\Exceptions;
+
+
+class ValidationDisabledException extends GenericException
+{
+
+}

--- a/Service/Exceptions/ValidationFailedException.php
+++ b/Service/Exceptions/ValidationFailedException.php
@@ -1,0 +1,10 @@
+<?php
+
+
+namespace Dutchento\Vatfallback\Service\Exceptions;
+
+
+class ValidationFailedException extends GenericException
+{
+
+}

--- a/Service/Exceptions/ValidationIgnoredException.php
+++ b/Service/Exceptions/ValidationIgnoredException.php
@@ -1,0 +1,10 @@
+<?php
+
+
+namespace Dutchento\Vatfallback\Service\Exceptions;
+
+
+class ValidationIgnoredException extends GenericException
+{
+
+}

--- a/Service/Exceptions/ValidationUnavailableException.php
+++ b/Service/Exceptions/ValidationUnavailableException.php
@@ -1,0 +1,10 @@
+<?php
+
+
+namespace Dutchento\Vatfallback\Service\Exceptions;
+
+
+class ValidationUnavailableException extends GenericException
+{
+
+}

--- a/Service/Validate/FailedValidationException.php
+++ b/Service/Validate/FailedValidationException.php
@@ -9,12 +9,13 @@
 
 namespace Dutchento\Vatfallback\Service\Validate;
 
-use RuntimeException;
+use Dutchento\Vatfallback\Service\Exceptions\ValidationFailedException;
 
 /**
  * Class FailedValidationException
  * @package Dutchento\Vatfallback\Service\Validate
+ * @deprecated in favor of \Dutchento\Vatfallback\Service\Exceptions\*
  */
-class FailedValidationException extends RuntimeException
+class FailedValidationException extends ValidationFailedException
 {
 }

--- a/Service/Validate/Regex.php
+++ b/Service/Validate/Regex.php
@@ -64,9 +64,10 @@ class Regex implements ValidationServiceInterface
 
         // as fallback use a pattern that always validates
         $regex = $vatPatternMap[$countryIso2] ?? '#.*#';
-        $result = preg_match($regex, $vatNumber);
 
-        if (false === $result) {
+        try {
+            $result = preg_match($regex, $vatNumber);
+        } catch (\Exception $exception) {
             throw new ValidationFailedException("RegExp error occured validating '{$vatNumber}' against '{$regex}'");
         }
 

--- a/Service/Validate/ValidationServiceInterface.php
+++ b/Service/Validate/ValidationServiceInterface.php
@@ -8,6 +8,8 @@
 
 namespace Dutchento\Vatfallback\Service\Validate;
 
+use Dutchento\Vatfallback\Service\Exceptions\GenericException;
+
 /**
  * Interface ValidationServiceInterface
  * @package Dutchento\Vatfallback\Service\Validate
@@ -27,6 +29,7 @@ interface ValidationServiceInterface
      * @param string $vatNumber
      * @param string $countryIso2
      * @return bool
+     * @throws GenericException
      */
     public function validateVATNumber(string $vatNumber, string $countryIso2): bool;
 }

--- a/Service/ValidateVat.php
+++ b/Service/ValidateVat.php
@@ -69,11 +69,11 @@ class ValidateVat implements ValidateVatInterface
 
             } catch (ValidationDisabledException $exception) {
                 // validation disabled, proceed next
-                $this->logger->debug("vatfallback {$validationName} disabled: {$exception->getMessage()}");
+                $this->logger->notice("vatfallback {$validationName} disabled: {$exception->getMessage()}");
 
             } catch (ValidationIgnoredException $exception) {
                 // validation ignored, proceed next
-                $this->logger->log("vatfallback {$validationName} ignored: {$exception->getMessage()}");
+                $this->logger->notice("vatfallback {$validationName} ignored: {$exception->getMessage()}");
 
             } catch (ValidationFailedException $exception) {
                 // validation failed, a problem occured

--- a/Service/Vatlayer/Client.php
+++ b/Service/Vatlayer/Client.php
@@ -9,93 +9,50 @@
 
 namespace Dutchento\Vatfallback\Service\Vatlayer;
 
-use Dutchento\Vatfallback\Service\ConfigurationInterface;
-use GuzzleHttp\Client as GuzzleClient;
-use RuntimeException;
-use Exception;
-
 /**
  * Class Client
  * @package Dutchento\Vatfallback\Service\Vatlayer
  */
-class Client
+class Client extends \GuzzleHttp\Client
 {
 
     /** @var null | array */
     protected static $validationResult = [];
 
-    /** @var ConfigurationInterface */
-    private $configuration;
 
-    /**
-     * Vatlayer constructor.
-     * @param ScopeConfigInterface $scopeConfig
-     */
-    public function __construct(
-        ConfigurationInterface $configuration
-    ) {
-        $this->configuration = $configuration;
+    public function __construct(array $config = [])
+    {
+        $config = array_merge([
+            'base_uri' => 'https://apilayer.com/'
+        ], $config);
+
+        parent::__construct($config);
     }
 
-    /**
-     * Call the Vatlayer API endpoint
-     * @param string $vatNumber
-     * @param string $countryIso2
-     * @return array
-     * @throws RuntimeException
-     */
-    public function retrieveVatnumberEndpoint(string $vatNumber, string $countryIso2): array
-    {
-        if (!$this->configuration->isVatlayerValidation()) {
-            throw new RuntimeException("Vatlayer isn't enabled");
-        }
-
-        $vatlayerApiKey = $this->configuration->getVatlayerApikey();
-        if (!$vatlayerApiKey) {
-            throw new RuntimeException("Vatlayer API key isn't setup, did you forget to configure vatlayer");
-        }
-
-        $vatlayerTimeout = $this->configuration->getVatlayerTimeout();
+    public function retrieveVatnumberEndpoint(
+            string $vatNumber,
+            string $countryIso2,
+            string $apiKey,
+            int $timeout = 1
+    ) {
 
         $cacheKey = $countryIso2 . $vatNumber;
         if (isset(self::$validationResult[$cacheKey])) {
             return self::$validationResult[$cacheKey];
         }
 
-        // call API layer endpoint
-        try {
-            $client = new GuzzleClient(['base_uri' => 'http://apilayer.net']);
+        $options = [
+            'connect_timeout' => max(1, $timeout),
+            'query' => [
+                'access_key' => $apiKey,
+                'vat_number' => $countryIso2 . $vatNumber,
+                'format' => 1
+            ]
+        ];
 
-            $response = $client->request('GET', '/api/validate', [
-                'connect_timeout' => max(1, $vatlayerTimeout),
-                'query' => [
-                    'access_key' => $vatlayerApiKey,
-                    'vat_number' => $countryIso2 . $vatNumber,
-                    'format' => 1
-                ]
-            ]);
-        } catch (Exception $error) {
-            throw new RuntimeException("HTTP error {$error->getMessage()}");
-        }
+        $response =  $this->request('GET', '/api/validate', $options);
+        self::$validationResult[$cacheKey] = $response;
 
-        $contents = $response->getBody()->getContents();
-
-        // did we get a valid statuscode
-        if ($response->getStatusCode() > 299) {
-            throw new RuntimeException(
-                "Vatlayer API responded with status {$response->getStatusCode()}, 
-                body {$contents}"
-            );
-        }
-
-        // Response body should be JSON
-        $result = json_decode($contents, true);
-        if (json_last_error() !== JSON_ERROR_NONE) {
-            throw new RuntimeException("No valid JSON response, body {$contents}");
-        }
-
-        // Cache result
-        self::$validationResult[$cacheKey] = $result;
-        return $result;
+        return $response;
     }
 }

--- a/Service/Vies/Client.php
+++ b/Service/Vies/Client.php
@@ -1,0 +1,51 @@
+<?php
+
+
+namespace Dutchento\Vatfallback\Service\Vies;
+
+
+/**
+ * Class Client
+ * @package Dutchento\Vatfallback\Service\Vatlayer
+ */
+class Client extends \GuzzleHttp\Client
+{
+
+    public function __construct(array $config = [])
+    {
+        $config = array_merge([
+            'base_uri' => 'http://ec.europa.eu'
+        ], $config);
+
+        parent::__construct($config);
+    }
+
+    public function getTaxationCustomsVies(
+        string $countryIso,
+        string $vatNumber,
+        string $merchantCountryCode,
+        string $merchantVatNumber,
+        int $connectionTimeout = 1
+    ) {
+
+        $options = [
+            'connect_timeout' => max(1, $connectionTimeout),
+            'query' => [
+                'ms' => $countryIso,
+                'iso' => $countryIso,
+                'vat' => $vatNumber,
+                'requesterMs' => $merchantCountryCode,
+                'requesterIso' => $merchantCountryCode,
+                'requesterVat' => $merchantVatNumber,
+                'BtnSubmitVat' => 'Verify',
+            ],
+        ];
+
+        return $this->request(
+            'GET', '
+            /taxation_customs/vies/viesquer.do',
+            $options
+        );
+    }
+
+}

--- a/Test/Unit/Service/ValidateVatTest.php
+++ b/Test/Unit/Service/ValidateVatTest.php
@@ -1,0 +1,267 @@
+<?php
+
+namespace Dutchento\Vatfallback\Test\Unit\Service;
+
+use Dutchento\Vatfallback\Service\CleanNumberString;
+use Dutchento\Vatfallback\Service\Exceptions\ValidationDisabledException;
+use Dutchento\Vatfallback\Service\Exceptions\ValidationFailedException;
+use Dutchento\Vatfallback\Service\Exceptions\ValidationIgnoredException;
+use Dutchento\Vatfallback\Service\Exceptions\ValidationUnavailableException;
+use Dutchento\Vatfallback\Service\Validate\ValidationServiceInterface;
+use Dutchento\Vatfallback\Service\ValidateVat;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+
+class ValidateVatTest extends TestCase
+{
+
+    /** @var LoggerInterface */
+    private $loggerInterfaceMock;
+    /** @var MockObject|CleanNumberString */
+    private $cleanNumberStringMock;
+
+    public function setUp()
+    {
+        $this->loggerInterfaceMock = $this->createMock(LoggerInterface::class);
+        $this->cleanNumberStringMock = $this->getMockBuilder(CleanNumberString::class)
+            ->disableOriginalConstructor()
+            ->setMethods(['returnStrippedString'])
+            ->getMock();
+    }
+
+    public function testByNumberAndCountryCallsCleanNumberStringWithoutValidators()
+    {
+        $cleanNumberString = $this->cleanNumberStringMock;
+
+        $cleanNumberString->expects($this->once())
+                ->method('returnStrippedString')
+                ->will($this->returnArgument(0));
+
+        $validateVat = new ValidateVat(
+            $this->loggerInterfaceMock,
+            $cleanNumberString
+        );
+
+        $this->assertSame([
+            'result' => false,
+            'service' => 'None'
+        ], $validateVat->byNumberAndCountry('123465', 'xx'));
+    }
+
+    public function testByNumberAndCountryExitAtFirstValidationIfInvalid()
+    {
+        $validatorMock = $this->createMock(ValidationServiceInterface::class);
+
+        $validatorMock->expects($this->once())
+                ->method('getValidationServiceName')
+                ->willReturn('first', 'second');
+
+        $validatorMock->expects($this->once())
+                ->method('validateVATNumber')
+                ->willReturn(false, false);
+
+        $validateVat = new ValidateVat(
+            $this->loggerInterfaceMock,
+            $this->cleanNumberStringMock,
+            [$validatorMock, $validatorMock]
+        );
+
+        $this->assertSame([
+            'result' => false,
+            'service' => 'first'
+        ], $validateVat->byNumberAndCountry('123456', 'xx'));
+    }
+
+    public function testByNumberAndCountryFirstValidatorIfValid()
+    {
+        $validatorMock = $this->createMock(ValidationServiceInterface::class);
+
+        $validatorMock->expects($this->once())
+            ->method('getValidationServiceName')
+            ->willReturn('first', 'second');
+
+        $validatorMock->expects($this->once())
+            ->method('validateVATNumber')
+            ->with('123456', 'xx')
+            ->willReturn(true, true);
+
+        $cleanNumberString = $this->cleanNumberStringMock;
+
+        $cleanNumberString->method('returnStrippedString')
+                ->willReturnArgument(0);
+
+        $validateVat = new ValidateVat(
+            $this->loggerInterfaceMock,
+            $cleanNumberString,
+            [$validatorMock, $validatorMock]
+        );
+
+        $this->assertSame([
+            'result' => true,
+            'service' => 'first'
+        ], $validateVat->byNumberAndCountry('123456', 'xx'));
+    }
+
+    public function testByNumberAndCountryExceptions()
+    {
+        $validationMock = $this->createMock(ValidationServiceInterface::class);
+
+        $validationMock->expects($this->exactly(4))
+            ->method('getValidationServiceName')
+            ->willReturn(
+                'disabled',
+                'ignored',
+                'unavailable',
+                'failed',
+                'valid'
+            );
+
+        $validationMock->expects($this->exactly(4))
+            ->method('validateVATNumber')
+            ->willReturn(
+                $this->throwException(new ValidationDisabledException('disabled-exception')),
+                $this->throwException(new ValidationIgnoredException('ignored-exception')),
+                $this->throwException(new ValidationUnavailableException('unavailable-exception')),
+                $this->throwException(new ValidationFailedException('failed-exception')),
+                true
+            );
+
+        $validateVat = new ValidateVat(
+            $this->loggerInterfaceMock,
+            $this->cleanNumberStringMock,
+            [$validationMock, $validationMock, $validationMock, $validationMock, $validationMock]
+        );
+
+        $this->assertSame([
+            'result' => false,
+            'service' => 'failed'
+        ], $validateVat->byNumberAndCountry('123456', 'xx'));
+    }
+
+    /**
+     * @param $result
+     * @param $validators
+     * @dataProvider dataProviderForFallbackScenarios
+     */
+    public function testByNumberAndCountryFallback($result, $validators)
+    {
+        $validateVat = new ValidateVat(
+            $this->loggerInterfaceMock,
+            $this->cleanNumberStringMock,
+            $validators
+        );
+
+        $this->assertSame($result, $validateVat->byNumberAndCountry('123456', 'xx'));
+    }
+
+    /**
+     * Data provider for remote services test and offline
+     *
+     * @return array
+     */
+    public function dataProviderForFallbackScenarios(): array
+    {
+
+        /**
+         * Examples taken from https://github.com/Dutchento/m2-vatfallback/issues/20
+         *
+         * 1: Remote service 1 -> VIES
+         * 2: Remote service 2 -> Vatlayer
+         * 3: Offline -> RegExp
+         *
+         * ? = unknown | - unavailable | * disabled | # invalid
+         *
+         * - R: [false, vies]: 1: false
+         * - R: [true, vies]: 1: true
+         *
+         * - R: [false, vatlayer]: 1: ?-* | 2: false
+         * - R: [true, vatlayer]: 1: ?-* | 2: true
+         *
+         * - R: [false, regexp]: 1: ?-* | 2: ?-* | 3: false
+         * - R: [true, regexp]: 1: ?-* | 2: ?-* | 3: true
+         *
+         * - R: [false, none]: 1: ?-* | 2: ?-* | 3: ?*
+         *
+         * - R: [false, vatlayer]: 1: ? | 2: # | 3: true
+         *
+         *
+         */
+        return [
+            'R: [false, vies]: 1: false' => [
+                $this->createValidatorResult(false, 'vies'),
+                $this->createValidatorMock([
+                    'vies' => false,
+                    'vatlayer' => false,
+                    'regexp' => false
+                ])
+            ],
+            'R: [true, vies]: 1: true' => [
+                $this->createValidatorResult(true, 'vies'),
+                $this->createValidatorMock([
+                    'vies' => true,
+                    'vatlayer' => false,
+                    'regexp' => false
+                ])
+            ],
+            'R: [false, vatlayer]: 1: *, 2: true' => [
+                $this->createValidatorResult(true, 'vatlayer'),
+                $this->createValidatorMock([
+                    'vies' => $this->throwException(new ValidationDisabledException),
+                    'vatlayer' => true,
+                    'regexp' => false
+                ])
+            ],
+            'R: [false, regexp]: 1: *, 2: -, 3: false' => [
+                $this->createValidatorResult(false, 'regexp'),
+                $this->createValidatorMock([
+                    'vies' => $this->throwException(new ValidationDisabledException),
+                    'vatlayer' => $this->throwException(new ValidationIgnoredException),
+                    'regexp' => false
+                ])
+            ],
+            'R: [false, none]: 1: *, 2: -, 3: ?' => [
+                $this->createValidatorResult(false, 'None'),
+                $this->createValidatorMock([
+                    'vies' => $this->throwException(new ValidationDisabledException),
+                    'vatlayer' => $this->throwException(new ValidationIgnoredException),
+                    'regexp' => $this->throwException(new ValidationUnavailableException)
+                ])
+            ],
+            'R: [false, vatlayer]: 1: *, 2: #, 3: ?' => [
+                $this->createValidatorResult(false, 'vatlayer'),
+                $this->createValidatorMock([
+                    'vies' => $this->throwException(new ValidationDisabledException),
+                    'vatlayer' => $this->throwException(new ValidationFailedException),
+                    'regexp' => $this->throwException(new ValidationUnavailableException)
+                ])
+            ],
+        ];
+
+    }
+
+    public function createValidatorResult($result, $service)
+    {
+        return [
+            'result' => $result,
+            'service' => $service
+        ];
+    }
+
+    public function createValidatorMock(array $services)
+    {
+        $validationMock = $this->createMock(ValidationServiceInterface::class);
+
+        $numServices = count($services);
+
+        $validationMock->method('getValidationServiceName')
+                ->willReturn(...array_keys($services));
+        $validationMock->method('validateVATNumber')
+                ->willReturn(...array_values($services));
+
+        return array_fill(0, $numServices, $validationMock);
+    }
+
+
+
+}

--- a/composer.json
+++ b/composer.json
@@ -2,6 +2,7 @@
     "name": "dutchento/m2-vatfallback",
     "description": "Provides free VAT fallback mechanism",
     "license": "MIT",
+    "type": "magento2-module",
     "authors": [
         {
             "name": "Sander Mangel",

--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -2,30 +2,38 @@
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_Config:etc/system_file.xsd">
 	<system>
 		<section id="customer">
-			<group id="vatfallback" showInDefault="1" showInStore="0" showInWebsite="0" sortOrder="10" translate="label">
+			<group id="vatfallback" showInDefault="1" showInStore="0" showInWebsite="0" sortOrder="10" translate="label comment">
 				<label>Vatfallback</label>
 				<comment>Vatfallback provides a more reliable way of validating VAT numbers by using both on- and offline fallback services</comment>
-				<field id="vies_validation" showInDefault="1" showInStore="0" showInWebsite="0" sortOrder="10" translate="label" type="select">
+
+				<field id="vies_validation" showInDefault="1" showInStore="0" showInWebsite="0" sortOrder="10" translate="label comment" type="select">
 					<label>Use unofficial VIES service</label>
 					<comment/>
 					<source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
 				</field>
-                <field id="vies_timeout" showInDefault="1" showInStore="0" showInWebsite="0" sortOrder="10" translate="label" type="text">
+                <field id="vies_timeout" showInDefault="1" showInStore="0" showInWebsite="0" sortOrder="15" translate="label comment" type="text">
                     <label>VIES API timeout (seconds)</label>
                     <comment><![CDATA[Timeout in seconds for connecting to the VIES API. The lower the less likely to get a hit, more will add to checkout time]]></comment>
                 </field>
-				<field id="vatlayer_validation" showInDefault="1" showInStore="0" showInWebsite="0" sortOrder="10" translate="label" type="select">
+
+				<field id="vatlayer_validation" showInDefault="1" showInStore="0" showInWebsite="0" sortOrder="20" translate="label comment" type="select">
 					<label>Use Vatlayer service</label>
 					<comment/>
 					<source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
 				</field>
-				<field id="vatlayer_apikey" showInDefault="1" showInStore="0" showInWebsite="0" sortOrder="10" translate="label" type="text">
+				<field id="vatlayer_apikey" showInDefault="1" showInStore="0" showInWebsite="0" sortOrder="25" translate="label comment" type="text">
 					<label>Vatlayer API key</label>
                     <comment><![CDATA[Register with <a href='https://vatlayer.com/product'>Vatlayer.com</a> to obtain an API key]]></comment>
 				</field>
-				<field id="vatlayer_timeout" showInDefault="1" showInStore="0" showInWebsite="0" sortOrder="10" translate="label" type="text">
+				<field id="vatlayer_timeout" showInDefault="1" showInStore="0" showInWebsite="0" sortOrder="28" translate="label comment" type="text">
 					<label>Vatlayer API timeout (seconds)</label>
                     <comment><![CDATA[The lower the less likely to get a hit, more will add to page request time in API, checkout]]></comment>
+				</field>
+
+				<field id="regexp_validation" showInDefault="1" showInStore="0" showInWebsite="0" sortOrder="30" translate="label comment" type="select">
+					<label>Regular Expression</label>
+					<comment><![CDATA[Use regular expressions to validate vat numbers]]></comment>
+					<source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
 				</field>
 			</group>
 		</section>

--- a/etc/config.xml
+++ b/etc/config.xml
@@ -9,6 +9,8 @@
 				<vatlayer_validation>0</vatlayer_validation>
 				<vatlayer_apikey></vatlayer_apikey>
 				<vatlayer_timeout>2</vatlayer_timeout>
+
+				<regexp_validation>1</regexp_validation>
 			</vatfallback>
 		</customer>
 	</default>


### PR DESCRIPTION
Thought of a way to get around the problem that if vies returns false(invalid) for sure, that this is leading, no further checking is done... if the service is however unavailable, disabled or ignored, fallback is done in sequence.

Exceptions:
- `Disabled`; service is disabled, pick-up next service
- `InvalidConfiguration`; service is enabled but missing parameters, check logging, pick-up next service
- `Failed`; Something went wrong in the service, will break, no further checking
- `Ignored`; Service can say, ignore, pick up next service
- `Unavailable`; Service unavailable, pick up next service

Added testing for these scenarios:

```
 /**
         * Examples taken from https://github.com/Dutchento/m2-vatfallback/issues/20
         *
         * 1: Remote service 1 -> VIES
         * 2: Remote service 2 -> Vatlayer
         * 3: Offline -> RegExp
         *
         * ? = unknown | - unavailable | * disabled | # invalid
         *
         * - R: [false, vies]: 1: false
         * - R: [true, vies]: 1: true
         *
         * - R: [false, vatlayer]: 1: ?-* | 2: false
         * - R: [true, vatlayer]: 1: ?-* | 2: true
         *
         * - R: [false, regexp]: 1: ?-* | 2: ?-* | 3: false
         * - R: [true, regexp]: 1: ?-* | 2: ?-* | 3: true
         *
         * - R: [false, none]: 1: ?-* | 2: ?-* | 3: ?*
         *
         * - R: [false, vatlayer]: 1: ? | 2: # | 3: true
         *
         *
         */
```
