### PR TITLE
Get things back to working again

### DIFF
--- a/Api/CompanyLookup.php
+++ b/Api/CompanyLookup.php
@@ -9,6 +9,8 @@
 
 namespace Dutchento\Vatfallback\Api;
 
+use Dutchento\Vatfallback\Api\Data\CompanyLookupResultInterface;
+use Dutchento\Vatfallback\Api\Data\CompanyLookupResultInterfaceFactory;
 use Dutchento\Vatfallback\Service\CleanNumberString;
 use Dutchento\Vatfallback\Service\ConfigurationInterface;
 use Dutchento\Vatfallback\Service\Vatlayer\Client as VatlayerClient;
@@ -32,6 +34,10 @@ class CompanyLookup implements CompanyLookupInterface
      * @var ConfigurationInterface
      */
     private $configuration;
+    /**
+     * @var CompanyLookupResultInterfaceFactory
+     */
+    private $resultFactory;
 
     /**
      * CompanyLookup constructor.
@@ -39,23 +45,26 @@ class CompanyLookup implements CompanyLookupInterface
      * @param LoggerInterface $logger
      * @param CleanNumberString $cleanNumberString
      * @param ConfigurationInterface $configuration
+     * @param CompanyLookupResultInterfaceFactory $resultFactory
      */
     public function __construct(
         VatlayerClient $vatlayerClient,
         LoggerInterface $logger,
         CleanNumberString $cleanNumberString,
-        ConfigurationInterface $configuration
+        ConfigurationInterface $configuration,
+        CompanyLookupResultInterfaceFactory $resultFactory
     ) {
         $this->vatlayerClient = $vatlayerClient;
         $this->logger = $logger;
         $this->cleanNumberString = $cleanNumberString;
         $this->configuration = $configuration;
+        $this->resultFactory = $resultFactory;
     }
 
     /**
      * @inheritdoc
      */
-    public function byVatnumber(string $vatNumber): array
+    public function byVatnumber(string $vatNumber): CompanyLookupResultInterface
     {
         $country = substr($vatNumber, 0, 2);
         $cleanVatnumber = $this->cleanNumberString->returnStrippedString($vatNumber);
@@ -70,21 +79,25 @@ class CompanyLookup implements CompanyLookupInterface
             );
             $data = json_decode($response->getBody(), true);
 
-            return [
-                'status' => $data['valid'] ?? false,
-                'country' => $data['country_code'] ?? 'Unknown',
-                'company_name' => $data['company_name'] ?? 'Unknown',
-                'company_address' => $data['company_address'] ?? 'Unknown',
-                'message' => $data['error']['message'] ?? '',
-            ];
+            return $this->resultFactory->create([
+                'data' => [
+                    'status' => $data['valid'] ?? false,
+                    'country' => $data['country_code'] ?? 'Unknown',
+                    'company_name' => $data['company_name'] ?? 'Unknown',
+                    'company_address' => $data['company_address'] ?? 'Unknown',
+                    'message' => $data['error']['message'] ?? '',
+                ],
+            ]);
         } catch (\Exception $exception) {
             $this->logger->error($exception->getMessage());
             $message = $exception->getMessage();
         }
 
-        return [
-            'status' => false,
-            'message' => $message
-        ];
+        return $this->resultFactory->create([
+            'data' => [
+                'status' => false,
+                'message' => $message,
+            ],
+        ]);
     }
 }

--- a/Api/CompanyLookupInterface.php
+++ b/Api/CompanyLookupInterface.php
@@ -9,6 +9,8 @@
 
 namespace Dutchento\Vatfallback\Api;
 
+use Dutchento\Vatfallback\Api\Data\CompanyLookupResultInterface;
+
 /**
  * Interface CompanyLookupInterface
  * @package Dutchento\Vatfallback\Api
@@ -20,7 +22,7 @@ interface CompanyLookupInterface
      *
      * @api
      * @param string $vatNumber vatnumber
-     * @return string[] Company data
+     * @return CompanyLookupResultInterface Company data
      */
-    public function byVatnumber(string $vatNumber): array;
+    public function byVatnumber(string $vatNumber): CompanyLookupResultInterface;
 }

--- a/Api/Data/CompanyLookupResult.php
+++ b/Api/Data/CompanyLookupResult.php
@@ -1,0 +1,95 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Dutchento\Vatfallback\Api\Data;
+
+use Magento\Framework\DataObject;
+
+class CompanyLookupResult extends DataObject implements CompanyLookupResultInterface
+{
+    /**
+     * @return bool
+     */
+    public function getStatus(): bool
+    {
+        return (bool) $this->getData(self::STATUS);
+    }
+
+    /**
+     * @param bool $status
+     * @return mixed|void
+     */
+    public function setStatus(bool $status)
+    {
+        $this->setData(self::STATUS, $status);
+    }
+
+    /**
+     * @return string
+     */
+    public function getCountry(): string
+    {
+        return $this->getData(self::COUNTRY);
+    }
+
+    /**
+     * @param string $country
+     * @return mixed|void
+     */
+    public function setCountry(string $country)
+    {
+        $this->setData(self::COUNTRY, $country);
+    }
+
+    /**
+     * @return string
+     */
+    public function getCompanyName(): string
+    {
+        return $this->getData(self::COMPANY_NAME);
+    }
+
+    /**
+     * @param string $companyName
+     * @return mixed|void
+     */
+    public function setCompanyName(string $companyName)
+    {
+        $this->setData(self::COMPANY_NAME, $companyName);
+    }
+
+    /**
+     * @return string
+     */
+    public function getCompanyAddress(): string
+    {
+        return $this->getData(self::COMPANY_ADDRESS);
+    }
+
+    /**
+     * @param string $companyAddress
+     * @return mixed|void
+     */
+    public function setCompanyAddress(string $companyAddress)
+    {
+        $this->setData(self::COMPANY_ADDRESS, $companyAddress);
+    }
+
+    /**
+     * @return string
+     */
+    public function getMessage(): string
+    {
+        return $this->getData(self::MESSAGE);
+    }
+
+    /**
+     * @param string $message
+     * @return mixed|void
+     */
+    public function setMessage(string $message)
+    {
+        $this->setData(self::MESSAGE, $message);
+    }
+}

--- a/Api/Data/CompanyLookupResultInterface.php
+++ b/Api/Data/CompanyLookupResultInterface.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Dutchento\Vatfallback\Api\Data;
+
+interface CompanyLookupResultInterface
+{
+    const STATUS = 'status';
+    const COUNTRY = 'country';
+    const COMPANY_NAME = 'company_name';
+    const COMPANY_ADDRESS = 'company_address';
+    const MESSAGE = 'message';
+
+    /**
+     * @return bool
+     */
+    public function getStatus(): bool;
+
+    /**
+     * @param bool $status
+     * @return mixed
+     */
+    public function setStatus(bool $status);
+
+    /**
+     * @return string
+     */
+    public function getCountry(): string;
+
+    /**
+     * @param string $country
+     * @return mixed
+     */
+    public function setCountry(string $country);
+
+    /**
+     * @return string
+     */
+    public function getCompanyName(): string;
+
+    /**
+     * @param string $companyName
+     * @return mixed
+     */
+    public function setCompanyName(string $companyName);
+
+    /**
+     * @return string
+     */
+    public function getCompanyAddress(): string;
+
+    /**
+     * @param string $companyAddress
+     * @return mixed
+     */
+    public function setCompanyAddress(string $companyAddress);
+
+    /**
+     * @return string
+     */
+    public function getMessage(): string;
+
+    /**
+     * @param string $message
+     * @return mixed
+     */
+    public function setMessage(string $message);
+}

--- a/Service/Configuration.php
+++ b/Service/Configuration.php
@@ -51,6 +51,13 @@ class Configuration implements ConfigurationInterface
             ->getConfig(self::XMLPATH_CUSTOMER_VATFALLBACK_VATLAYER_APIKEY);
     }
 
+    public function getVatlayerHttpsEnabled(StoreInterface $store = null): bool
+    {
+        return (bool) $this->storeManager
+            ->getStore($store)
+            ->getConfig(self::XMLPATH_CUSTOMER_VATFALLBACK_VATLAYER_USE_HTTPS);
+    }
+
     public function getVatlayerTimeout(StoreInterface $store = null): int
     {
         return +$this->storeManager

--- a/Service/ConfigurationInterface.php
+++ b/Service/ConfigurationInterface.php
@@ -8,14 +8,14 @@ use Magento\Store\Api\Data\StoreInterface;
 interface ConfigurationInterface
 {
 
-    const XMLPATH_CUSTOMER_VATFALLBACK_VIES_VALIDATION = 'vatfallback/vatfallback/vies_validation';
-    const XMLPATH_CUSTOMER_VATFALLBACK_VIES_TIMEOUT = 'vatfallback/vatfallback/vies_timeout';
+    const XMLPATH_CUSTOMER_VATFALLBACK_VIES_VALIDATION = 'customer/vatfallback/vies_validation';
+    const XMLPATH_CUSTOMER_VATFALLBACK_VIES_TIMEOUT = 'customer/vatfallback/vies_timeout';
 
-    const XMLPATH_CUSTOMER_VATFALLBACK_VATLAYER_VALIDATION = 'vatfallback/vatfallback/vatlayer_validation';
-    const XMLPATH_CUSTOMER_VATFALLBACK_VATLAYER_APIKEY = 'vatfallback/vatfallback/vatlayer_apikey';
-    const XMLPATH_CUSTOMER_VATFALLBACK_VATLAYER_TIMEOUT = 'vatfallback/vatfallback/vatlayer_timeout';
+    const XMLPATH_CUSTOMER_VATFALLBACK_VATLAYER_VALIDATION = 'customer/vatfallback/vatlayer_validation';
+    const XMLPATH_CUSTOMER_VATFALLBACK_VATLAYER_APIKEY = 'customer/vatfallback/vatlayer_apikey';
+    const XMLPATH_CUSTOMER_VATFALLBACK_VATLAYER_TIMEOUT = 'customer/vatfallback/vatlayer_timeout';
 
-    const XMLPATH_CUSTOMER_VATFALLBACK_REGEXP_VALIDATION = 'vatfallback/vatfallback/regexp_validation';
+    const XMLPATH_CUSTOMER_VATFALLBACK_REGEXP_VALIDATION = 'customer/vatfallback/regexp_validation';
 
     public function isViesValidation(StoreInterface $store = null): bool;
     public function getViesTimeout(StoreInterface $store = null): int;

--- a/Service/ConfigurationInterface.php
+++ b/Service/ConfigurationInterface.php
@@ -7,14 +7,14 @@ use Magento\Store\Api\Data\StoreInterface;
 
 interface ConfigurationInterface
 {
-
     const XMLPATH_CUSTOMER_VATFALLBACK_VIES_VALIDATION = 'customer/vatfallback/vies_validation';
     const XMLPATH_CUSTOMER_VATFALLBACK_VIES_TIMEOUT = 'customer/vatfallback/vies_timeout';
 
     const XMLPATH_CUSTOMER_VATFALLBACK_VATLAYER_VALIDATION = 'customer/vatfallback/vatlayer_validation';
     const XMLPATH_CUSTOMER_VATFALLBACK_VATLAYER_APIKEY = 'customer/vatfallback/vatlayer_apikey';
+    const XMLPATH_CUSTOMER_VATFALLBACK_VATLAYER_USE_HTTPS = 'customer/vatfallback/vatlayer_use_https';
     const XMLPATH_CUSTOMER_VATFALLBACK_VATLAYER_TIMEOUT = 'customer/vatfallback/vatlayer_timeout';
-
+    
     const XMLPATH_CUSTOMER_VATFALLBACK_REGEXP_VALIDATION = 'customer/vatfallback/regexp_validation';
 
     public function isViesValidation(StoreInterface $store = null): bool;
@@ -22,6 +22,7 @@ interface ConfigurationInterface
 
     public function isVatlayerValidation(StoreInterface $store = null): bool;
     public function getVatlayerApikey(StoreInterface $store = null): string;
+    public function getVatlayerHttpsEnabled(StoreInterface $store = null): bool;
     public function getVatlayerTimeout(StoreInterface $store = null): int;
 
     public function isRegExpValidation(StoreInterface $store = null): bool;

--- a/Service/Validate/Vatlayer.php
+++ b/Service/Validate/Vatlayer.php
@@ -76,7 +76,7 @@ class Vatlayer implements ValidationServiceInterface
                     $this->configuration->getVatlayerHttpsEnabled()
                 );
         } catch (Exception $exception) {
-            throw new ValidationUnavailableException("API unavailable {$error->getMessage()}");
+            throw new ValidationUnavailableException("API unavailable {$exception->getMessage()}");
         }
 
         $contents = $response->getBody()->getContents();

--- a/Service/Validate/Vatlayer.php
+++ b/Service/Validate/Vatlayer.php
@@ -61,7 +61,7 @@ class Vatlayer implements ValidationServiceInterface
         }
 
         $apiKey = $this->configuration->getVatlayerApikey();
-        if ($apiKey) {
+        if (empty($apiKey)) {
             throw new InvalidConfigurationException('Vatlayer API is not setup correctly');
         }
 

--- a/Service/Validate/Vatlayer.php
+++ b/Service/Validate/Vatlayer.php
@@ -72,7 +72,8 @@ class Vatlayer implements ValidationServiceInterface
                     $vatNumber,
                     $countryIso2,
                     $apiKey,
-                    $this->configuration->getVatlayerTimeout()
+                    $this->configuration->getVatlayerTimeout(),
+                    $this->configuration->getVatlayerHttpsEnabled()
                 );
         } catch (Exception $exception) {
             throw new ValidationUnavailableException("API unavailable {$error->getMessage()}");

--- a/Service/Validate/Vies.php
+++ b/Service/Validate/Vies.php
@@ -88,7 +88,7 @@ class Vies implements ValidationServiceInterface
             throw new ValidationUnavailableException("API unavailable returns: status {$response->getStatusCode()} '{$contents}'");
         }
 
-        if (false !== strpos($responseBody, 'No, invalid VAT number')) {
+        if (false !== strpos($contents, 'No, invalid VAT number')) {
             return false;
         }
 

--- a/Service/ValidateVat.php
+++ b/Service/ValidateVat.php
@@ -36,16 +36,16 @@ class ValidateVat implements ValidateVatInterface
      *
      * @param LoggerInterface $logger
      * @param CleanNumberString $cleanNumberString
-     * @param ValidationServiceInterface[] $validationSerives
+     * @param ValidationServiceInterface[] $validationServices
      */
     public function __construct(
         LoggerInterface $logger,
         CleanNumberString $cleanNumberString,
-        array $validationSerives = []
+        array $validationServices = []
     ) {
         $this->logger = $logger;
         $this->cleanNumberString = $cleanNumberString;
-        $this->validationServices = $validationSerives;
+        $this->validationServices = $validationServices;
     }
 
     /**
@@ -57,16 +57,13 @@ class ValidateVat implements ValidateVatInterface
 
         /** @var ValidationServiceInterface $validationService */
         foreach ($this->validationServices as $validationService) {
-
             $validationName = $validationService->getValidationServiceName();
             try {
-
                 $result = $validationService->validateVATNumber($cleanVatString, $countryIso2);
                 return [
                     'result' => $result,
                     'service' => $validationName
                 ];
-
             } catch (ValidationDisabledException $exception) {
                 // validation disabled, proceed next
                 $this->logger->notice("vatfallback {$validationName} disabled: {$exception->getMessage()}");
@@ -83,7 +80,6 @@ class ValidateVat implements ValidateVatInterface
                     'result' => false,
                     'service' => $validationName
                 ];
-
             } catch (GenericException $exception) {
                 // Generic exception, log and continue
                 $this->logger->error("vatfallback {$validationName} error: {$exception->getMessage()}");

--- a/Service/Vatlayer/Client.php
+++ b/Service/Vatlayer/Client.php
@@ -15,27 +15,16 @@ namespace Dutchento\Vatfallback\Service\Vatlayer;
  */
 class Client extends \GuzzleHttp\Client
 {
-
     /** @var null | array */
     protected static $validationResult = [];
 
-
-    public function __construct(array $config = [])
-    {
-        $config = array_merge([
-            'base_uri' => 'https://apilayer.com/'
-        ], $config);
-
-        parent::__construct($config);
-    }
-
     public function retrieveVatnumberEndpoint(
-            string $vatNumber,
-            string $countryIso2,
-            string $apiKey,
-            int $timeout = 1
+        string $vatNumber,
+        string $countryIso2,
+        string $apiKey,
+        int $timeout = 1,
+        bool $secure = false
     ) {
-
         $cacheKey = $countryIso2 . $vatNumber;
         if (isset(self::$validationResult[$cacheKey])) {
             return self::$validationResult[$cacheKey];
@@ -46,11 +35,14 @@ class Client extends \GuzzleHttp\Client
             'query' => [
                 'access_key' => $apiKey,
                 'vat_number' => $countryIso2 . $vatNumber,
-                'format' => 1
-            ]
+                'format' => 1,
+            ],
         ];
 
-        $response =  $this->request('GET', '/api/validate', $options);
+        $scheme = 'http' . ($secure ? 's' : '');
+        $url = $scheme . '://apilayer.net/api/validate';
+
+        $response = $this->request('GET', $url, $options);
         self::$validationResult[$cacheKey] = $response;
 
         return $response;

--- a/Service/Vies/Client.php
+++ b/Service/Vies/Client.php
@@ -27,7 +27,6 @@ class Client extends \GuzzleHttp\Client
         string $merchantVatNumber,
         int $connectionTimeout = 1
     ) {
-
         $options = [
             'connect_timeout' => max(1, $connectionTimeout),
             'query' => [
@@ -42,10 +41,9 @@ class Client extends \GuzzleHttp\Client
         ];
 
         return $this->request(
-            'GET', '
-            /taxation_customs/vies/viesquer.do',
+            'GET',
+            '/taxation_customs/vies/viesquer.do',
             $options
         );
     }
-
 }

--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -25,6 +25,10 @@
 					<label>Vatlayer API key</label>
                     <comment><![CDATA[Register with <a href='https://vatlayer.com/product'>Vatlayer.com</a> to obtain an API key]]></comment>
 				</field>
+                <field id="vatlayer_use_https" showInDefault="1" showInStore="0" showInWebsite="0" sortOrder="26" translate="label comment" type="select">
+                    <label>Vatlayer HTTPS</label>
+                    <comment><![CDATA[Requires Vatlayer subscription plan >= <a href='https://vatlayer.com/product'>Basic Plan</a>.]]></comment>
+                </field>
 				<field id="vatlayer_timeout" showInDefault="1" showInStore="0" showInWebsite="0" sortOrder="28" translate="label comment" type="text">
 					<label>Vatlayer API timeout (seconds)</label>
                     <comment><![CDATA[The lower the less likely to get a hit, more will add to page request time in API, checkout]]></comment>

--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -28,6 +28,7 @@
                 <field id="vatlayer_use_https" showInDefault="1" showInStore="0" showInWebsite="0" sortOrder="26" translate="label comment" type="select">
                     <label>Vatlayer HTTPS</label>
                     <comment><![CDATA[Requires Vatlayer subscription plan >= <a href='https://vatlayer.com/product'>Basic Plan</a>.]]></comment>
+                    <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
                 </field>
 				<field id="vatlayer_timeout" showInDefault="1" showInStore="0" showInWebsite="0" sortOrder="28" translate="label comment" type="text">
 					<label>Vatlayer API timeout (seconds)</label>

--- a/etc/config.xml
+++ b/etc/config.xml
@@ -8,6 +8,7 @@
 
 				<vatlayer_validation>0</vatlayer_validation>
 				<vatlayer_apikey></vatlayer_apikey>
+				<vatlayer_use_https>0</vatlayer_use_https>
 				<vatlayer_timeout>2</vatlayer_timeout>
 
 				<regexp_validation>1</regexp_validation>

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -49,7 +49,7 @@
     </type>
     <type name="Dutchento\Vatfallback\Service\ValidateVat">
         <arguments>
-            <argument name="validationSerives" xsi:type="array">
+            <argument name="validationServices" xsi:type="array">
                 <item name="vies" xsi:type="object">Dutchento\Vatfallback\Service\Validate\Vies</item>
                 <item name="vatlayer" xsi:type="object">Dutchento\Vatfallback\Service\Validate\Vatlayer</item>
                 <item name="regexp" xsi:type="object">Dutchento\Vatfallback\Service\Validate\Regex</item>

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -3,6 +3,8 @@
         xsi:noNamespaceSchemaLocation="urn:magento:framework:ObjectManager/etc/config.xsd">
     <preference for="Dutchento\Vatfallback\Api\CompanyLookupInterface"
                 type="Dutchento\Vatfallback\Api\CompanyLookup"/>
+    <preference for="Dutchento\Vatfallback\Api\Data\CompanyLookupResultInterface"
+                type="Dutchento\Vatfallback\Api\Data\CompanyLookupResult"/>
     <preference for="Dutchento\Vatfallback\Service\ValidateVatInterface"
                 type="Dutchento\Vatfallback\Service\ValidateVat"/>
     <preference for="Dutchento\Vatfallback\Model\VatNumber\ConfigInterface"


### PR DESCRIPTION
I found out that the current state of `m2-vatfallback` is close to unusable when one wants to use Vatlayer. Here's a list of things that I fixed:
- Fix system configuration being useless because of bad values in the xml path constants (see [etc/adminhtml/system.xml](https://github.com/Dutchento/m2-vatfallback/blob/master/etc/adminhtml/system.xml)).
- Fix typo (`validationSerives` => `validationServices`).
- Fix vatlayer service not working when an api key is configured.
- Fix vatlayer service not working because url is outdated.
- Fix vatlayer service not working when account is on free plan (https is not available on this plan). 
- Fix multiple php undefined variable errors.
- Fix fatal error (object used as array) in CompanyLookup
- Change API companylookup data structure