### PR TITLE
Rewind stream when returning cached response

### DIFF
--- a/Service/Vatlayer/Client.php
+++ b/Service/Vatlayer/Client.php
@@ -27,6 +27,7 @@ class Client extends \GuzzleHttp\Client
     ) {
         $cacheKey = $countryIso2 . $vatNumber;
         if (isset(self::$validationResult[$cacheKey])) {
+            self::$validationResult[$cacheKey]->getBody()->rewind();
             return self::$validationResult[$cacheKey];
         }
 


### PR DESCRIPTION
With saving the response in the cache the `->getBody()->getContents()` in de response is already red in the stream, so a second time the  `->getBody()->getContents()` is called it is returning an empty string, with rewinding the stream is set to starting point. 

Maybe this can be refactored in the future, by not saving the response but the  `->getBody()->getContents()` like before, but for now internal caching is not working, so fixed with this PR.