### PR TITLE
Fix webapi exception caused by incorrect phpdoc type

### DIFF
--- a/Api/CompanyLookupInterface.php
+++ b/Api/CompanyLookupInterface.php
@@ -22,7 +22,7 @@ interface CompanyLookupInterface
      *
      * @api
      * @param string $vatNumber vatnumber
-     * @return CompanyLookupResultInterface Company data
+     * @return \Dutchento\Vatfallback\Api\Data\CompanyLookupResultInterface Company data
      */
     public function byVatnumber(string $vatNumber): CompanyLookupResultInterface;
 }


### PR DESCRIPTION
Fixes error `Message: The \"CompanyLookupResultInterface\" class doesn't exist and the namespace must be specified.`