### PR TITLE
Better handling exceptions for make request success not determined by validity of vat number

### DIFF
--- a/Plugin/Magento/Customer/Model/Vat.php
+++ b/Plugin/Magento/Customer/Model/Vat.php
@@ -101,13 +101,13 @@ class Vat
      * @return DataObject
      * @throws \Exception
      */
-    public function createGatewayResponseObject(string $vatNumber, bool $success, string $message): DataObject
+    public function createGatewayResponseObject(string $vatNumber, bool $isValid, string $message): DataObject
     {
         return new DataObject([
-            'is_valid' => $success,
+            'is_valid' => $isValid,
             'request_date' => (new \DateTimeImmutable())->format('Y-m-d'),
             'request_identifier' => $vatNumber,
-            'request_success' => $success,
+            'request_success' => true,
             'request_message' => $message,
         ]);
     }

--- a/Service/ValidateVat.php
+++ b/Service/ValidateVat.php
@@ -76,11 +76,6 @@ class ValidateVat implements ValidateVatInterface
             } catch (ValidationFailedException $exception) {
                 // validation failed, a problem occured
                 $this->logger->error("vatfallback {$validationName} failed: {$exception->getMessage()}");
-
-                return [
-                    'result' => false,
-                    'service' => $validationName
-                ];
             } catch (GenericException $exception) {
                 // Generic exception, log and continue
                 $this->logger->error("vatfallback {$validationName} error: {$exception->getMessage()}");


### PR DESCRIPTION
ValidationFailedException returns the vat number validity result is false, but this is a false negative, because ValidationFailedException implies the vatservice has some issues like incorrect api key. This shouldn't cause the vat number validity result to be invalid because the vatnumber checked could be valid.