### PR TITLE
add support for greece vat numbers

### DIFF
--- a/Plugin/Service/Validate/ValidationService.php
+++ b/Plugin/Service/Validate/ValidationService.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Dutchento\Vatfallback\Plugin\Service\Validate;
+
+use Dutchento\Vatfallback\Service\Validate\ValidationServiceInterface;
+
+class ValidationService
+{
+    public function beforeValidateVATNumber(ValidationServiceInterface $subject, string $vatNumber, string $countryIso2): array
+    {
+        return [$vatNumber, $this->getCountryCodeForVatNumber($countryIso2)];
+    }
+
+    /**
+     * Returns the country code to use in the VAT number which is not always the same as the normal country code
+     *
+     * @param string $countryCode
+     * @return string
+     */
+    private function getCountryCodeForVatNumber(string $countryCode): string
+    {
+        // Greece uses a different code for VAT numbers then its country code
+        // See: http://ec.europa.eu/taxation_customs/vies/faq.html#item_11
+        // And https://en.wikipedia.org/wiki/VAT_identification_number:
+        // "The full identifier starts with an ISO 3166-1 alpha-2 (2 letters) country code
+        // (except for Greece, which uses the ISO 639-1 language code EL for the Greek language,
+        // instead of its ISO 3166-1 alpha-2 country code GR)"
+
+        return $countryCode === 'GR' ? 'EL' : $countryCode;
+    }
+}

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -16,6 +16,11 @@
         <plugin name="Dutchento_Vatfallback_Plugin_Magento_Customer_Model_Vat" sortOrder="10"
                 type="Dutchento\Vatfallback\Plugin\Magento\Customer\Model\Vat"/>
     </type>
+    <type name="Dutchento\Vatfallback\Service\Validate\ValidationServiceInterface">
+        <plugin name="Dutchento_Vatfallback_Plugin_Service_Validate_ValidationServiceInterface" sortOrder="10"
+                type="Dutchento\Vatfallback\Plugin\Service\Validate\ValidationService"/>
+    </type>
+
     <type name="Magento\Framework\Console\CommandList">
         <arguments>
             <argument name="commands" xsi:type="array">


### PR DESCRIPTION
Greece uses a different code for VAT numbers then its country code. Greece uses the ISO 639-1 language code EL for the Greek language instead of its ISO 3166-1 alpha-2 country code GR.

Magento 2 is doing this like: https://github.com/magento/magento2/blob/f121ac8359768b5ebcc7462574e58c36f34c52df/app/code/Magento/Customer/Model/Vat.php#L314

Instead of coding this in to one of the concrete functions, I choose to make a before plugin for all classes using the `ValidationServiceInterface` to convert 'GR' to 'EL', so other validation services or custom made validation services will also have the proper country code for Greece as a param. 