### PR TITLE
Update Guzzle version to match Magento 2.4.4 & PHP 8.1

### DIFF
--- a/Model/VatNumber/Config/Converter.php
+++ b/Model/VatNumber/Config/Converter.php
@@ -63,7 +63,7 @@ class Converter implements ConverterInterface
     {
         $pattern = trim($pattern);
         $pattern = '/' . trim($pattern, '/') . '/';
-        if (preg_match($pattern, null) === false) {
+        if (preg_match($pattern, '') === false) {
             throw new \InvalidArgumentException("Regex pattern '{$pattern}' does not appear to be valid");
         }
 

--- a/Service/CleanNumberString.php
+++ b/Service/CleanNumberString.php
@@ -28,7 +28,7 @@ class CleanNumberString
                 '/[^0-9a-z]+/i'
             ],
             '',
-            $vatInput
+            $vatInput ?? ''
         );
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
         "magento/framework": "^100.0|^101.0|^102.0|^103.0",
         "magento/module-customer": "^101.0|^102.0|^103.0",
         "psr/log": "^1.0",
-        "guzzlehttp/guzzle": "^6.2",
+        "guzzlehttp/guzzle": "^6.2|^7.0",
         "ext-json": "*",
         "ext-dom": "*"
     },


### PR DESCRIPTION
Magento 2.4.4 requires Guzzle 7.3, so its updated.
I do need to test this though, the pull-request is here only to save you a bit of time.