### PR TITLE
Add Official VIES as a service and don't use core Magento VIES request

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,8 @@
         "psr/log": "^1.0",
         "guzzlehttp/guzzle": "^6.2|^7.0",
         "ext-json": "*",
-        "ext-dom": "*"
+        "ext-dom": "*",
+        "ext-soap": "*"
     },
     "require-dev": {
         "phpunit/phpunit": "^6.2"

--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -4,10 +4,10 @@
 		<section id="customer">
 			<group id="vatfallback" showInDefault="1" showInStore="0" showInWebsite="0" sortOrder="10" translate="label comment">
 				<label>Vatfallback</label>
-				<comment>Vatfallback provides a more reliable way of validating VAT numbers by using both on- and offline fallback services</comment>
+				<comment>Vatfallback provides a more reliable way of validating VAT numbers by using both on- and offline services</comment>
 
 				<field id="vies_validation" showInDefault="1" showInStore="0" showInWebsite="0" sortOrder="10" translate="label comment" type="select">
-					<label>Use unofficial VIES service</label>
+					<label>Use VIES service</label>
 					<comment/>
 					<source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
 				</field>


### PR DESCRIPTION
## Problems
### The 'unofficial VIES service' is broken
At the moment this module includes an option for '[unofficial VIES service](https://github.com/Dutchento/m2-vatfallback/blob/master/Service/Validate/Vies.php)' but this does not work anymore because the endpoint is no more.

### The Caching problem
We would like to cache any Vies services results ([see pr](https://github.com/Dutchento/m2-vatfallback/pull/41)).
But at the moment the core plugin code lets Magento do the VIES request first and only if that fails the fallback-services will be called (including the cache one).

This way the VIES result is never cached (but is terribly slow, so caching is quite nice).

## Solution

1. Refactor '[Unofficial VIES service](https://github.com/Dutchento/m2-vatfallback/blob/master/Service/Validate/Vies.php)' to use the official VIES SOAP endpoint (just like [Magento core](https://github.com/magento/magento2/blob/320c2e51e1ee7d9fe99498cb7031e3b7b86bfeca/app/code/Magento/Customer/Model/Vat.php#L162) does)
2. Remove the [Magento core Vies request](https://github.com/Dutchento/m2-vatfallback/blob/master/Plugin/Magento/Customer/Model/Vat.php#L72) from the code so the new Vies service can take over (if you want)

## Note
This will effectively make this module behave as a 'vat-replacement-with-fallbacks' and not only as 'vat-fallback'.