### PR TITLE
Fix call to undefined method getBody()

### DIFF
--- a/Service/Vies/Client.php
+++ b/Service/Vies/Client.php
@@ -28,7 +28,6 @@ class Client
     ): mixed {
         $cacheKey = $countryIso . $vatNumber;
         if (isset(self::$validationResult[$cacheKey])) {
-            self::$validationResult[$cacheKey]->getBody()->rewind();
             return self::$validationResult[$cacheKey];
         }
         $soapClient = $this->createVatNumberValidationSoapClient(false, $timeout);


### PR DESCRIPTION
If caching is disabled in the configuration, and VAT validation is performed multiple times per request (so that the result remains in the class property), an error "Call to undefined method stdClass::getBody()" occurs, which is quite logical because the result variable indeed does not have that method. And this line of code is a remnant of copied code from Vatlayer/Client, where it did make sense. 
Please accept my changes.