### PR TITLE
Check Vatlayer database return field for failure

### DIFF
--- a/Service/Validate/Vatlayer.php
+++ b/Service/Validate/Vatlayer.php
@@ -96,8 +96,16 @@ class Vatlayer implements ValidationServiceInterface
             throw new ValidationFailedException('Vatlayer could not be queried ' . $result['error']['info']);
         }
 
-        if (! isset($result['valid'])) {
+        if ((! isset($result['valid'])) || (! isset($result['database']))) {
             throw new ValidationIgnoredException('Vatlayer did not return validation');
+        }
+
+        if ($result['database'] === 'failure') {
+            throw new ValidationFailedException('Vatlayer returns: database failure (could not connect to member state)');
+        }
+
+        if ($result['database'] !== 'ok') {
+            throw new ValidationFailedException('Vatlayer database not ok');
         }
 
         return (bool)$result['valid'];


### PR DESCRIPTION
Vatlayer returns a 'database' field as [documented](https://vatlayer.com/documentation#database_status).
We need to make sure the database field is 'ok' otherwise the returned 'valid' field does not reflect if the vat-number is actually valid or not.

> Important: In order to make use of vatlayer validation results in the most effective and reliable way, it is highly recommended to check whether or not the necessary database connection could be established before taking any actions based on the validation result contained in the API's valid object.
